### PR TITLE
[LUM-744] WebApp -> Investigate sdk v0.8.5 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lum-network/sdk-javascript",
-    "version": "0.8.6",
+    "version": "0.8.7",
     "license": "Apache-2.0",
     "description": "Javascript SDK library for NodeJS and Web browsers to interact with the Lum Network.",
     "homepage": "https://github.com/lum-network/sdk-javascript#readme",

--- a/src/utils/accounts.ts
+++ b/src/utils/accounts.ts
@@ -15,7 +15,8 @@ function uint64FromProto(input: Long) {
 
 function accountFromBaseAccount(input: BaseAccount): LumTypes.Account {
     const { address, pubKey, accountNumber, sequence } = input;
-    const pubkey = decodePubkey(pubKey as Any);
+    const pubkey = pubKey ? decodePubkey(pubKey) : null;
+
     return {
         address: address,
         pubkey: pubkey,


### PR DESCRIPTION
This fixes the error `Cannot read properties of undefined (reading 'typeUrl')` occurring on some wallets when trying to sign and broadcast a transaction.